### PR TITLE
Fixed Gnome Terminal version number bug

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ schemes=($(cd $dir/colors && echo * && cd - > /dev/null))
 
 source $dir/src/tools.sh
 source $dir/src/profiles.sh
-source $dir/src/dircolors.sh
+#source $dir/src/dircolors.sh
 
 show_help() {
   echo

--- a/src/profiles.sh
+++ b/src/profiles.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.*[.].*[.].*\)$')"
+gnomeVersion="$(expr "$(gnome-terminal --version)" | cut -d" " -f3)"
 dircolors_checked=false
 
 


### PR DESCRIPTION
The regex version always returns the last matched version number. And, that's always not correct.